### PR TITLE
fixed updateSubmissionOutput bug only sending zeroth output element

### DIFF
--- a/server/src/utils/engine.js
+++ b/server/src/utils/engine.js
@@ -53,7 +53,7 @@ const executeCode = async (submissionId, cellId, code, notebookId) => {
   } finally {
     writableStream.end();
     console.log('arr', arr)
-    updateSubmissionOutput(submissionId, cellId, isSyntaxOrRuntimeError, arr[0]);
+    updateSubmissionOutput(submissionId, cellId, isSyntaxOrRuntimeError, arr.join(''));
   }
 }
 


### PR DESCRIPTION
The bug: sending code input that would output multiple lines was only sending back the first log statement. e.g., 

`console.log(1); console.log(2); console.log(3);`
=> 1

Fixed by joining the output stream array in `engine.js` in our call to `updateSubmissionOutput`