### PR TITLE
circular dependencies and modularizing const/let cleaning

### DIFF
--- a/server/src/utils/compileFrontendInput.js
+++ b/server/src/utils/compileFrontendInput.js
@@ -1,0 +1,106 @@
+const { resetContext, getVariableMap, getCellsRun, getFlagged, getChangedVariables, updateVariableMap, updateCellsRun, updateFlagged, updateChangedVariables } = require('./context');
+const {extractVariables} = require("./extractVariables");
+
+const variableMap = getVariableMap();
+const cellsRun = getCellsRun();
+const flagged = getFlagged();
+const changedVariables = getChangedVariables()
+
+const compileFrontendInput = (cell, notebookId) => {
+ //first check if cell has been ran (has implications immediately and throughout)
+      let previouslyRan = false;
+      let needABreak = false;
+      if (!cellsRun[cell.cellId]) {
+        updateCellsRun(cell.cellId, 1)
+      } else {
+        previouslyRan = true;
+        updateCellsRun(cell.cellId, cellsRun[cell.cellId] + 1)
+      }
+      //then extract variables and check them against the variable map  
+      //payload below is {variables:[], values:[]}, but can change it to just [] (variables)
+      const cellVariables = extractVariables(cell.code);
+      if (previouslyRan) {
+        console.log('here')
+        //check all variables in this cell (cellVariables)
+        //if they are in variableMap, extract const/let/var from just in front of that one
+          //if they are not in variableMap, leave be
+        for (let variable of cellVariables.variables) {
+          if (variableMap[variable]) {
+            let replaced = `const ${variable}`;
+            let replaced2 = `let ${variable}`;
+            let replaced3 = `var ${variable}`;
+            //if has been run previously and has const, dont want to break the code, instead, reset context
+            if (variableMap[variable] == 2 && (cell.code.match(replaced2) || cell.code.match(replaced3))) {
+              needABreak = true;
+              console.log('broke out because const had been declared earlier')
+              break;
+            }
+
+            //now we mark the variable to be changed (on backend only)
+            if (cell.code.match(`const ${variable}`) || variableMap[variable] == 2) {
+              updateFlagged(variable)
+              updateChangedVariables(variable, cell.cellId)
+              cell.code = cell.code.replace(replaced, `${variable}${cellsRun[cell.cellId]}`);
+            }
+            cell.code = cell.code.replace(replaced2, variable);
+            cell.code = cell.code.replace(replaced3, variable);
+          }
+        }
+        //if the variable is in changedVariable make sure we replace it in any of these situations
+        Object.keys(changedVariables).forEach(variable => {
+          cell.code = cell.code.replace(` ${variable} `, ` ${variable}${cellsRun[cell.cellId]} `)
+          cell.code = cell.code.replace(` ${variable},`, ` ${variable}${cellsRun[cell.cellId]},`)
+          cell.code = cell.code.replace(`,${variable},`, `,${variable}${cellsRun[cell.cellId]},`)
+          cell.code = cell.code.replace(`,${variable}`, `,${variable}${cellsRun[cell.cellId]}`)
+          cell.code = cell.code.replace(` ${variable}.`, ` ${variable}${cellsRun[cell.cellId]}.`)
+          cell.code = cell.code.replace(`.${variable}.`, `.${variable}${cellsRun[cell.cellId]}.`)
+          cell.code = cell.code.replace(`.${variable}`, `.${variable}${cellsRun[cell.cellId]}`)
+        }) 
+        //if has been run previously and has const, break out of outer loop and reset context
+        if (needABreak) {
+          executeCode(submissionId, cell.cellId, cell.code, notebookId);
+          delete cellsRun[cell.cellId];
+          resetContext(notebookId);
+          console.log('broke out from running all cells bc of const has already been run already')
+        //   break;
+        return 'broken';
+        }
+      } else {
+        //check all variables in cellVariables
+          //if they are in variableMap, 
+            //1throw Error('variable declared twice (DO WE WANT THE CELL IT WAS DECLARED IN?)')
+            //2reset context which runs current + allPrev
+        let errorRiden = false;
+        for (let i=0; i< cellVariables.variables.length; i++) {    
+          if (variableMap[cellVariables.variables[i]]) {
+            errorRiden = true;
+            console.log('broke out from not-run previously variable check bc of duplicate')
+            break;
+          }
+        }
+        if (errorRiden) {
+          executeCode(submissionId, cell.cellId, cell.code, notebookId);
+          delete cellsRun[cell.cellId];
+          resetContext(notebookId);
+          console.log('broke out from running all cells bc of a not-run-prev duplicate')
+        //   break;
+        return 'broken';
+        }
+      }
+
+      cell.code.split(' ').forEach(word => {
+        if (changedVariables[word]) {
+          cell.code.replaceAll(word, changedVariables[word])
+        }
+      })
+
+      cellVariables.variables.forEach((variable, index) => {
+        updateVariableMap(variable, true);
+          if (flagged[variable] || cell.code.match(`const ${variable}`)) {
+          updateVariableMap(variable, 2)
+        }
+      })
+
+}
+
+module.exports = {compileFrontendInput};

--- a/server/src/utils/context.js
+++ b/server/src/utils/context.js
@@ -14,7 +14,7 @@ should FE have an active context indicator?
 
 Take in a notebook.
 */
-const main = require("./engine");
+// const main = require("./engine");
 
 const contextStore = {
   "111": {
@@ -22,6 +22,43 @@ const contextStore = {
     lastUpdate: 1687812247076,
     context: {}
   }
+}
+
+const variableMap = {};
+const cellsRun = {};
+const flagged = {};
+const changedVariables = {}
+
+const updateVariableMap = (variable, value) => {
+  variableMap[variable] = value;
+}
+
+const updateCellsRun = (cellId, value) => {
+  cellsRun[cellId] = value
+}
+
+const updateFlagged = (variable) => {
+  flagged[variable] = true;
+}
+
+const updateChangedVariables = (variable, cellId) => {
+  changedVariables[variable] = `${variable}${cellsRun[cellId]}` 
+}
+
+const getVariableMap = () => {
+  return variableMap;
+}
+
+const getCellsRun = () => {
+  return cellsRun;
+}
+
+const getFlagged = () => {
+  return flagged;
+}
+
+const getChangedVariables = () => {
+  return changedVariables;
 }
 
 const loadContext = (notebookId) => {
@@ -44,13 +81,13 @@ const resetContext = (notebookId) => {
   contextStore[notebookId].active = false;
   contextStore[notebookId].context = {};
   //resets the in-memory state of context in engine.js
-  for (var member in main.variableMap) delete main.variableMap[member];
-  for (var member in main.cellsRun) delete main.cellsRun[member];
-  for (var member in main.flagged) delete main.flagged[member];
+  for (var member in variableMap) delete variableMap[member];
+  for (var member in cellsRun) delete cellsRun[member];
+  for (var member in flagged) delete flagged[member];
 }
 
 const updateContextWrapper = (notebookId) => {
   contextStore[notebookId].lastUpdate = Date.now();
 }
 
-module.exports = { loadContext, updateContextWrapper, resetContext};
+module.exports = { loadContext, updateContextWrapper, resetContext, getVariableMap, getCellsRun, getFlagged, getChangedVariables, updateVariableMap, updateCellsRun, updateFlagged, updateChangedVariables};

--- a/server/src/utils/engine.js
+++ b/server/src/utils/engine.js
@@ -1,111 +1,14 @@
 const vm = require('vm');
 const { Console } = require('console');
-const { loadContext, updateContextWrapper, resetContext } = require('./context');
+const { loadContext, updateContextWrapper } = require('./context');
 const { updateSubmissionOutput } = require('./submissionOutput');
-const {extractVariables} = require("./extractVariables");
-
-//below has implications: is this engine containerized per session? assumption yes
-//if so, we dont need to worry about everyone else's variables polluting the maps below
-const variableMap = {};
-const cellsRun = {};
-const flagged = {};
+const {compileFrontendInput} = require("./compileFrontendInput");
 
 const engine = async (submissionId, cells, notebookId) => {
-  let changedVariables = {}
   for (let cell of cells) {    
     try {
-      //first check if cell has been ran (has implications immediately and throughout)
-      let previouslyRan = false;
-      let needABreak = false;
-      if (!cellsRun[cell.cellId]) {
-        cellsRun[cell.cellId] = 1;
-      } else {
-        previouslyRan = true;
-        cellsRun[cell.cellId] += 1;
-      }
-      //then extract variables and check them against the variable map  
-      //payload below is {variables:[], values:[]}, but can change it to just [] (variables)
-      const cellVariables = extractVariables(cell.code);
-      if (previouslyRan) {
-        console.log('here')
-        //check all variables in this cell (cellVariables)
-        //if they are in variableMap, extract const/let/var from just in front of that one
-          //if they are not in variableMap, leave be
-        for (let variable of cellVariables.variables) {
-          if (variableMap[variable]) {
-            let replaced = `const ${variable}`;
-            let replaced2 = `let ${variable}`;
-            let replaced3 = `var ${variable}`;
-            //if has been run previously and has const, dont want to break the code, instead, reset context
-            if (variableMap[variable] == 2 && (cell.code.match(replaced2) || cell.code.match(replaced3))) {
-              needABreak = true;
-              console.log('broke out because const had been declared earlier')
-              break;
-            }
-
-            //now we mark the variable to be changed (on backend only)
-            if (cell.code.match(`const ${variable}`) || variableMap[variable] == 2) {
-              flagged[variable] = true;
-              changedVariables[variable] = `${variable}${cellsRun[cell.cellId]}` 
-              cell.code = cell.code.replace(replaced, `${variable}${cellsRun[cell.cellId]}`);
-            }
-            cell.code = cell.code.replace(replaced2, variable);
-            cell.code = cell.code.replace(replaced3, variable);
-          }
-        }
-        //if the variable is in changedVariable make sure we replace it in any of these situations
-        Object.keys(changedVariables).forEach(variable => {
-          cell.code = cell.code.replace(` ${variable} `, ` ${variable}${cellsRun[cell.cellId]} `)
-          cell.code = cell.code.replace(` ${variable},`, ` ${variable}${cellsRun[cell.cellId]},`)
-          cell.code = cell.code.replace(`,${variable},`, `,${variable}${cellsRun[cell.cellId]},`)
-          cell.code = cell.code.replace(`,${variable}`, `,${variable}${cellsRun[cell.cellId]}`)
-          cell.code = cell.code.replace(` ${variable}.`, ` ${variable}${cellsRun[cell.cellId]}.`)
-          cell.code = cell.code.replace(`.${variable}.`, `.${variable}${cellsRun[cell.cellId]}.`)
-          cell.code = cell.code.replace(`.${variable}`, `.${variable}${cellsRun[cell.cellId]}`)
-        }) 
-        //if has been run previously and has const, break out of outer loop and reset context
-        if (needABreak) {
-          executeCode(submissionId, cell.cellId, cell.code, notebookId);
-          delete cellsRun[cell.cellId];
-          resetContext(notebookId);
-          console.log('broke out from running all cells bc of const has already been run already')
-          break;
-        }
-      } else {
-        //check all variables in cellVariables
-          //if they are in variableMap, 
-            //1throw Error('variable declared twice (DO WE WANT THE CELL IT WAS DECLARED IN?)')
-            //2reset context which runs current + allPrev
-        let errorRiden = false;
-        for (let i=0; i< cellVariables.variables.length; i++) {    
-          if (variableMap[cellVariables.variables[i]]) {
-            errorRiden = true;
-            console.log('broke out from not-run previously variable check bc of duplicate')
-            break;
-          }
-        }
-        if (errorRiden) {
-          executeCode(submissionId, cell.cellId, cell.code, notebookId);
-          delete cellsRun[cell.cellId];
-          resetContext(notebookId);
-          console.log('broke out from running all cells bc of a not-run-prev duplicate')
-          break;
-        }
-      }
-
-      cell.code.split(' ').forEach(word => {
-        if (changedVariables[word]) {
-          cell.code.replaceAll(word, changedVariables[word])
-        }
-      })
-
-      cellVariables.variables.forEach((variable, index) => {
-        variableMap[variable] = true;
-          if (flagged[variable] || cell.code.match(`const ${variable}`)) {
-          variableMap[variable] = 2;
-        }
-      })
-
+      let compiler = compileFrontendInput(cell, notebookId);
+      if (compiler === 'broken') break;
     executeCode(submissionId, cell.cellId, cell.code, notebookId);
     } catch (error) {
       console.error("running cells raised an error: ", error);
@@ -151,7 +54,5 @@ const executeCode = async (submissionId, cellId, code, notebookId) => {
 
 
 module.exports = {engine};
-exports.variableMap = variableMap;
-exports.cellsRun = cellsRun;
-exports.flagged = flagged;
+
 


### PR DESCRIPTION
TOP LEVEL:
--fixed circular dependencies issue between engine.js and context.js
--extracted out the logic for cleaning frontend input into its own module (hopefully making engine.js more 'declarative' and readable)

LOW LEVEL
--should we change the name of 'compile Front end' module/method  (maybe more like 'clean front end input‘?  
    --not sure technically what 'compile' entails and this is probably closer to 'reformatting the input for our own internal logic', is that what 'compile' means?
--should we extract the creation of a stream (about 10 lines of code) from the executeCode function in engine.js?