### PR TITLE
Timeout error handling in routes

### DIFF
--- a/server/src/utils/executionTimeout.js
+++ b/server/src/utils/executionTimeout.js
@@ -1,0 +1,20 @@
+const submissionIdTimeCreated = {};
+const DEFAULT_TIMEOUT = 10000 // 10 seconds;
+
+const createTimestamp = (submissionId, timeout) => {
+  submissionIdTimeCreated[submissionId] = {
+    timestamp: Date.now(),
+    timeout: timeout || DEFAULT_TIMEOUT,
+  }
+}
+
+const elapsedTime = (submissionId) => {
+  const startTime = submissionIdTimeCreated[submissionId].timestamp;
+  return Date.now() - startTime;
+}
+
+const exceedsTimeout = (submissionId) => {
+  return elapsedTime(submissionId) > submissionIdTimeCreated[submissionId].timeout;
+}
+
+module.exports = { exceedsTimeout, createTimestamp };


### PR DESCRIPTION
Upgraded server routes to take timeout
**`executionTimeout.js`** module
* `createTimestamp` method adds the submissionId and time to an in-memory map during `submit` route
* `exceedsTimeout` used in get `status` route. If status is null or still pending, it sends a 200 http response and `"timeout exceeded"` as the body status.

Todo: We need to think about distinguishing between timeouts due to client-code and timeouts due to system failures so that we can issue the appropriate responses. For example, the current implemntation does not distinguish between a user's infinitely looping code and a worker going down.