### PR TITLE
docker run cmd used in place of docker compose; configuring worker QUEUE_NAME with vars; refactor of child_proc logic

### DIFF
--- a/server/src/utils/workerTerminal.js
+++ b/server/src/utils/workerTerminal.js
@@ -1,0 +1,65 @@
+const fs = require('fs');
+const child_process = require('child_process');
+
+function wait(ms) {
+  var start = new Date().getTime();
+  var end = start;
+  while (end < start + ms) {
+    end = new Date().getTime();
+  }
+}
+
+var interface = {
+  terminal: child_process.spawn('/bin/sh'),
+  handler: console.log,
+  send: (data) => {
+    interface.terminal.stdin.write(data + '\n');
+  },
+  cwd: () => {
+    let cwd = fs.readlinkSync('/proc/' + interface.terminal.pid + '/cwd');
+    interface.handler({ type: 'cwd', data: cwd });
+  }
+};
+
+// Handle Data
+interface.terminal.stdout.on('data', (buffer) => {
+  interface.handler({ type: 'data', data: buffer });
+});
+
+// Handle Error
+interface.terminal.stderr.on('data', (buffer) => {
+  interface.handler({ type: 'error', data: buffer });
+});
+
+// Handle Closure
+interface.terminal.on('close', () => {
+  interface.handler({ type: 'closure', data: null });
+});
+
+//USE INTERFACE
+//! spin up another docker worker here
+interface.handler = (output) => {
+  let data = '';
+  if (output.data) data += ': ' + output.data.toString();
+  console.log("from the cmd line", output.type + data);
+};
+
+
+const createNewWorker = (notebookId) => {
+  const DOCKER_RUN_CMD = `docker run -d \
+  --name worker.${notebookId} \
+  --network dredd-network \
+  -e QUEUE_NAME=${notebookId} \
+  -v ./app \
+  -w /app \
+  node-worker`;
+
+  interface.send('cd ../worker')
+  interface.send('pwd');
+  wait(10);  //.01 seconds in milliseconds
+  interface.send(DOCKER_RUN_CMD);
+  wait(10);  //.01 seconds in milliseconds
+}
+
+
+module.exports = { createNewWorker }

--- a/worker/app/config/rabbitmq.js
+++ b/worker/app/config/rabbitmq.js
@@ -1,107 +1,10 @@
-// // const amqp = require('amqp-connection-manager');
-// // const { engine } = require('../engine.js');
-
-// // const QUEUE_NAME = 'judge'
-// // const connection = amqp.connect(['amqp://rabbitmq:5672']);
-
-// // connection.on('connect', function () {
-// //     console.log('Connected!');
-// // });
-
-// // connection.on('disconnect', function (err) {
-// //     console.log('Disconnected.', err);
-// // });
-
-// // const onMessage = (data) => {
-
-// //     let message = JSON.parse(data.content.toString());
-// //     console.log('message', message);
-// //     engine(message, channelWrapper, data);
-// // }
-
-// // // Set up a channel listening for messages in the queue.
-// // const channelWrapper = connection.createChannel({
-// //     setup: function (channel) {
-// //         // `channel` here is a regular amqplib `ConfirmChannel`.
-// //         console.log('set up channel')
-// //         return Promise.all([
-// //             channel.assertQueue(QUEUE_NAME, { durable: true }),
-// //             channel.prefetch(1),
-// //             channel.consume(QUEUE_NAME, onMessage)
-// //         ]);
-// //     }
-// // });
-
-// // channelWrapper.waitForConnect()
-// //     .then(function () {
-// //         console.log("Listening for messages");
-// //     });
-
-// const amqp = require("amqplib");
-
-
-// async function connect() {
-
-//     try {
-//         const amqpServer = "amqp://localhost:5672"
-//         const connection = await amqp.connect(amqpServer);
-//         console.log('connection');
-//         const channel = await connection.createChannel();
-//         console.log('channel set')
-//         //changed below
-//         const onMessage = (data) => {
-
-//             let message = JSON.parse(data.content.toString());
-//             console.log('message', message);
-//             engine(message, channelWrapper, data);
-//         }
-//         await channel.assertQueue("jobs");
-//         // return Promise.all([
-//         //                 channel.assertQueue(QUEUE_NAME, { durable: true }),
-//         //                 channel.prefetch(1),
-//         //                 channel.consume(QUEUE_NAME, onMessage)
-//         //             ]);
-        
-//         //above
-        
-//         channel.consume("jobs", onMessage
-//         // message => {
-//         //     const input = JSON.parse(message.content.toString());
-//         //     console.log(`Recieved job with input ${input.number}`)
-//         //     //"7" == 7 true
-//         //     //"7" === 7 false
-
-//         //     if (input.number == 7 ) 
-//         //         channel.ack(message);
-//         // }
-//         )
-
-//         console.log("Waiting for messages...")
-    
-//     }
-//     catch (ex){
-//         console.error(ex)
-//     }
-
-// }
-
-// // connect();
-
-// module.exports = {connect};
-
-
-
-
-
-
-
-
 const amqp = require("amqp-connection-manager");
-// const amqp from 'amqp-connection-manager';
 const { engine } = require('../engine.js')
 
-const QUEUE_NAME = 'jobs'
-// const connection = amqp.connect(['amqp://localhost:5672']);
+// QUEUE_NAME is roomId; passed during docker compose up
+// e.g., QUEUE_NAME='room24' docker compose up
+const QUEUE_NAME = process.env.QUEUE_NAME || 'jobs';
+console.log("QUEUE_NAME IS ", QUEUE_NAME);
 const connection = amqp.connect(['amqp://rabbitmq-dredd:5672']);
 
 connection.on('connect', function () {
@@ -141,6 +44,5 @@ channelWrapper.waitForConnect()
 
 
 
-// }
 
 module.exports = {listenMessage}

--- a/worker/docker-compose.yml
+++ b/worker/docker-compose.yml
@@ -5,10 +5,11 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    ports:
-      - 3000:3000
+
     networks:
       - dredd-network
+    environment:
+      - QUEUE_NAME=${QUEUE_NAME}
 
 networks:
   dredd-network:


### PR DESCRIPTION
**child process calls docker run command instead of docker compose files**. 
Instead of creating separate docker compose files for each worker configuration, the server side logic now executes this docker run command, which takes env variable args:

```text
`docker run -d \
  --name worker.${notebookId} \
  --network dredd-network \
  -e QUEUE_NAME=${notebookId} \
  -v ./app \
  -w /app \
  node-worker`;
```
**`worker.{notebookId}`** is now the container identifier 
**`QUEUE_NAME`** is the roomId and is used for queue assertion by the consumer.

**refactor of child process logic from routes to `workerTerminal.js`**
exports method `createNewWorker` for creating new worker based on `notebookId` (becomes the part of the container name, and used for the consumer queue name)