### PR TITLE
Added script execution time limits, which can be set by workerManager…

### DIFF
--- a/server/src/utils/workerManager.js
+++ b/server/src/utils/workerManager.js
@@ -1,3 +1,7 @@
+const NETWORK_NAME = 'dredd-network';
+const MEMORY_LIMIT = 100; // in mb;
+const SCRIPT_TIMEOUT_SECONDS = 8;
+
 const Docker = require('dockerode');
 const docker = new Docker();
 const fs = require('fs');
@@ -48,11 +52,16 @@ interface.handler = (output) => {
 
 
 const createNewWorker = (notebookId) => {
+  console.log('Deploying new worker for notebookId: ', notebookId);
+  console.log(`Memory limit is ${MEMORY_LIMIT}mb`);
+  console.log(`Script timeout is ${SCRIPT_TIMEOUT_SECONDS} seconds`);
+
   const DOCKER_RUN_CMD = `docker run -d \
-  -m 256m --memory-swap 256m \
+  -m ${MEMORY_LIMIT}m --memory-swap ${MEMORY_LIMIT}m \
   --name worker.${notebookId} \
-  --network dredd-network \
+  --network ${NETWORK_NAME} \
   -e QUEUE_NAME=${notebookId} \
+  -e SCRIPT_TIMEOUT_S=${SCRIPT_TIMEOUT_SECONDS} \
   -v ./app \
   -w /app \
   node-worker`;

--- a/worker/app/engine.js
+++ b/worker/app/engine.js
@@ -1,3 +1,5 @@
+const  SCRIPT_TIMEOUT_S = process.env.SCRIPT_TIMEOUT_S || 10;
+
 const vm = require('vm');
 const { client } = require("./config/redis.js");
 const { Console } = require('console');
@@ -56,9 +58,10 @@ const executeCode = async (submissionId, cellId, code, notebookId) => {
   context.console = customConsole;
 
   let isSyntaxOrRuntimeError = false;
+  // copilot, are you there?
 
   try {
-    await vm.runInNewContext(code, context);
+    await vm.runInNewContext(code, context, { timeout: SCRIPT_TIMEOUT_S *  1000 });
     updateContextWrapper(notebookId);
   } catch (error) {
     arr.push(String(error));


### PR DESCRIPTION
The engine's `vm.runInNewContext` now accepts option to limit execution time(timeout). We can edit the timeout among other deployment settings from `workerManager.js`, lines 1 -3.

**An advantage here is that we can log and write outputs to Redis, rather than simply waiting for the execution to  just crash the container**

For instance:
```
while (true) {console.log('Hi')};
// **Outputs: 'Hi'\n'Hi'\n'Hi'\n'Hi'\n'Hi'\n'Hi'\n'Hi'\n'Hi'\n'Hi'\n ... Error: Script execution timed out after 8000ms**
```