### PR TITLE
Rewrite of frontend compiler

### DIFF
--- a/worker/app/engine.js
+++ b/worker/app/engine.js
@@ -1,4 +1,4 @@
-const  SCRIPT_TIMEOUT_S = process.env.SCRIPT_TIMEOUT_S || 10;
+const SCRIPT_TIMEOUT_S = process.env.SCRIPT_TIMEOUT_S || 10;
 
 const vm = require('vm');
 const { client } = require("./config/redis.js");
@@ -9,7 +9,9 @@ const { compileFrontendInput } = require("./utils/compileFrontendInput.js");
 const { connect } = require("./config/rabbitmq.js");
 const { setRedisHashkey, getAllFields } = require('./utils/redisHelpers.js');
 const { get } = require('http');
-console.log('Worker last updated Jul 12, 2023 10:01:35 AM ')
+console.log('Worker last updated Jul 14, 2023 12:14:35 PM ')
+
+
 
 const engine = async (apiBody, ch, msg) => {
   console.log('apiBody', apiBody)
@@ -21,13 +23,15 @@ const engine = async (apiBody, ch, msg) => {
   for (let cell of apiBody.cells) {
     try {
       let compiler = compileFrontendInput(cell, apiBody.notebookId);
-console.log('COMPILER', compiler);
-      if (compiler === 'reset') {
-        console.log('RESETRESETUP')
-        //!
-        resetContext(apiBody.notebookId);
-        console.log('reset context first')
-      }
+      console.log('COMPILER 💀', compiler);
+
+      // if (compiler === 'reset') {
+      //   console.log('RESETRESETUP')
+      //   //!
+      //   resetContext(apiBody.notebookId);
+      //   console.log('reset context first')
+      // }
+
       let result = executeCode(apiBody.folder, cell.cellId, cell.code, apiBody.notebookId);
       //!
       // if (compiler === 'reset') {
@@ -35,7 +39,7 @@ console.log('COMPILER', compiler);
       //   setTimeout(() => {
       //     resetContext(apiBody.notebookId);
       //   }, 2000)
-        
+
       // }
 
     } catch (error) {
@@ -69,7 +73,7 @@ const executeCode = async (submissionId, cellId, code, notebookId) => {
   // copilot, are you there?
 
   try {
-    await vm.runInNewContext(code, context, { timeout: SCRIPT_TIMEOUT_S *  1000 });
+    await vm.runInNewContext(code, context, { timeout: SCRIPT_TIMEOUT_S * 1000 });
     updateContextWrapper(notebookId);
   } catch (error) {
     arr.push(String(error));

--- a/worker/app/utils/compileFrontendInput.js
+++ b/worker/app/utils/compileFrontendInput.js
@@ -1,5 +1,5 @@
-const { resetContext, getVariableMap, getCellsRun, getDeclaredAt, getChangedVariables, updateVariableMap, updateCellsRun, updateDeclaredAt, updateChangedVariables } = require('./context');
-const {extractVariables} = require("./extractVariables");
+const { resetContext, getVariableMap, getCellsRun, getDeclaredAt, getChangedVariables, updateVariableMap, updateCellsRun, updateDeclaredAt, updateChangedVariables, varDeclaredInThisCell, typeofDeclaration, setVarInMapV2, getVarFromMapV2, getVarMapV2 } = require('./context');
+const { extractVariables } = require("./extractVariables");
 
 const variableMap = getVariableMap();
 const cellsRun = getCellsRun();
@@ -8,142 +8,158 @@ const declaredAt = getDeclaredAt();
 //!
 let resetter = false;
 
-const compileFrontendInput = (cell, notebookId) => {
-//third, extract all variables from the current cell
-const cellVariables = extractVariables(cell.code);
-let prevRan = false;
-//!first check if prevRun
-if (cellsRun[cell.cellId]) {
-  prevRan=true;
-} else {
-  cellsRun[cell.cellId] = true;
-}
-//!if not ran previously putting var in var map
-// if (prevRan === false) {
-//   cellVariables.variables.forEach(variable => {
-//     variableMap[variable.type[0]][variable.name] = cell.cellId;
-//     console.log('variableMap', variableMap)
-//   })
-// }
-if (prevRan === true) {
-  // cellVariables.variables.forEach(async(variable) => {
-    //!FOR EACH VARIABLE
-    for (let i=0; i<cellVariables.variables.length; i++) {
-      //!
-      let variable = cellVariables.variables[i];
-      console.log(variable);
-      //!if variable declared previously in this cell
-    if (variableMap['const'][variable.name] === cell.cellId || variableMap['let'][variable.name] === cell.cellId || variableMap['var'][variable.name] === cell.cellId) {
-      //strip let/const/var only in first instance of variable
-      for (let i=0; i<variable.name.length; i++) {
-        let k = 6+ variable.name.length;
-        if (cell.code.slice(i, i+k) === `const ${variable.name}`) {
-          console.log('cell.code', cell.code)
-          if (i===0) {
-            cell.code = cell.code.slice(6);
-          } else {
-            cell.code = cell.code.slice(0,i) + cell.code.slice(i+6);
-          }
-          // cell.code.split('').splice(i, 6).join('');
-          console.log('cell.code', cell.code)
-          //!
-          resetter = true;
-          break;
-        }
-        if (cell.code.slice(i, i+k-2) === `let ${variable.name}`) {
-          console.log('cell.code', cell.code)
-          if (i===0) {
-            cell.code = cell.code.slice(4);
-          } else {
-            cell.code = cell.code.slice(0,i) + cell.code.slice(i+4);
-          }
-          // cell.code.split('').splice(i, 4).join('');
-          console.log('cell.code', cell.code)
-          //!MOST RECENTLY ADDED
-          resetter = true;
-          break;
-        }
-      }  
-      //!DELETE BELOW?
-      //! if cell run before and var declared w const then reset
-      //!OR be stringent, dont let people change a const
-      //!expected to fail if run 2x
-      if (resetter) {
-        resetter = false;
-      return 'reset'
-      }
-    } else {
-      //!if variable declared prev but not in this cell
-        //!dont do anything
-      //!if variable not declared previously
-        //! dont do anything
-      //reset context
-      console.log('before reset')
-      // resetContext(notebookId);
-      console.log('variableMapbefore', variableMap)
-      console.log('after reset before cellsId')
-      //! possible duplication
-      //!CAN PROB GET RID OF 
-      cellsRun[cell.cellId] = true;
-      console.log('after cellId before variableMap')
-      //!variables newly added to prev ran cell are now in map
-      //!CAN PROB GET RID OF 
-      variableMap[variable.type[0]][variable.name] = cell.cellId;
-      console.log('after variablemap')
-      console.log('variableMap', variableMap)
-      //delete the other entry for the variable in the map 
-      //and create an entry for the proper variable type
-      //!
-      // return 'reset';
-    }
-    //!
-  // })
-    }
-}
-// console.log(cellVariables);
-// let sameRun = {};
-// let sameRunCheckPassed = true;
-// for (let i=0; i< cellVariables.variables.length; i++) {
-//   if (sameRun[cellVariables.variables[i]]){
-//     console.log('sameRunFailed')
-//     sameRunCheckPassed = false;
-//   }
-//   sameRun[variable] = true;
-// }
+// const declaredInThisCell = (variable, cellId) => {
+//   return variableMap['const'][variable.name] === cellId || variableMap['let'][variable.name] === cellId || variableMap['var'][variable.name] === cellId;
 
-// if (sameRunCheckPassed) {
-//   //first replace all instances of const and var and let with ' '
-//       if (cell.code.match(/\bconst\b/)) {
-//         console.log('cell.code after', cell.code)
-//         cell.code = cell.code.replace(/const/g, '');
-//         console.log('cell.code after', cell.code)
-//         }
-//       if (cell.code.match(/\bvar\b/)) {
-//       cell.code = cell.code.replace(/var/g, '');
-//       }
-//       if (cell.code.match(/\blet\b/)) {
-//         cell.code = cell.code.replace(/let/g, '');
-//         }
-//       }
-// //second make sure the variables are in the variable map so can be accessed throughout the environment
-//           cellVariables.variables.forEach((variable, index) => {
-//               updateVariableMap(variable, true);
-//           })
-//!
-// return 'reset';
-//!populate variable map every time (unless reset)
-//!ADDED MOST RECENTLY
-cellVariables.variables.forEach(variable => {
-  // if (variableMap['const'][variable.name] === cell.cellId || !variableMap['let'][variable.name]=== cell.cellId || !variableMap['var'][variable.name]=== cell.cellId) {
-  //   delete variableMap['const'][variable.name];
-  //   delete variableMap['let'][variable.name];
-  //   delete variableMap['var'][variable.name];
-  // }
-    if (!variableMap['const'][variable.name] && !variableMap['let'][variable.name] && !variableMap['var'][variable.name]) {
-  variableMap[variable.type[0]][variable.name] = cell.cellId;
+
+const findDeclaration =  (keyword, variableName, cellContent) => {
+  const regex = new RegExp('(?:^|;|\\n)\\s*' + keyword + '\\s+' + variableName + '\\s*=', 'g');
+  const matches = [...cellContent.matchAll(regex)];
+  if (matches.length === 0) {
+    return [-1, -1];
   }
-  console.log('variableMap', variableMap)
-})
+
+  for (const match of matches) {
+    const substringBeforeMatch = cellContent.substring(0, match.index);
+    const openBrackets = (substringBeforeMatch.match(/{/g) || []).length;
+    const closeBrackets = (substringBeforeMatch.match(/}/g) || []).length;
+
+    if (openBrackets === closeBrackets) {
+      const variableNameStartIndex = match[0].indexOf(variableName);
+      return [match.index, match.index + variableNameStartIndex];
+    }
+  }
+
+  return [-1, -1];
 }
 
-module.exports = {compileFrontendInput};
+const compileFrontendInput = (cell, notebookId) => {
+  console.log('variableMap at start: ', getVarMapV2())
+  //third, extract all variables from the current cell
+
+  // ! This extracts function inner scoped variables as well. This will prevent us from compiling same-cell let declarations into reassignments.
+  const cellVariables = extractVariables(cell.code);
+  console.log(cellVariables);
+
+  let prevRan = false;
+  //!first check if prevRun
+  if (cellsRun[cell.cellId]) {
+    prevRan = true;
+  } else {
+    cellsRun[cell.cellId] = true;
+  }
+
+  for (let i = 0; i < cellVariables.variables.length; i++) {
+    const candidate = cellVariables.variables[i];
+    const exists = varDeclaredInThisCell(candidate.name, cell.cellId);
+    console.log(`does ${candidate.name} exist in this cell?`, exists);
+
+    if (!exists) continue;
+
+    const declarationType = typeofDeclaration(candidate.name);
+
+    if (declarationType === 'const') {
+      console.log(`${candidate.name} is a const`);
+      console.log('Doing nothing for now')
+
+    } else if (declarationType === 'let') {
+      console.log(`${candidate.name} is a let`);
+      const [start, size] = findDeclaration('let', candidate.name, cell.code);
+
+      if (start === -1) {
+        console.error(`Could not find declaration for ${candidate.name}`);
+        continue;
+      };
+
+      cell.code = cell.code.slice(0, start) + cell.code.slice(start + size);
+    };
+  }
+
+  // if (prevRan === true) {
+  //   // cellVariables.variables.forEach(async(variable) => {
+  //   //!FOR EACH VARIABLE
+  //   for (let i = 0; i < cellVariables.variables.length; i++) {
+  //     //!
+  //     let variable = cellVariables.variables[i];
+  //     console.log('this var is called: ', variable);
+  //     //!if variable declared previously in this cell
+  //     const decPrev = varDeclaredInThisCell(variable, cell.cellId);
+  //     console.log(`was ${variable.name} declared previously in this cell?`, decPrev);
+
+  //     if (varDeclaredInThisCell(variable, cell.cellId)) {
+  //       //strip let/const/var only in first instance of variable
+
+  //       const declarationType = typeofDeclaration(variable);
+  //       console.log('declarationType 🐑', declarationType);
+
+  //       for (let i = 0; i < variable.name.length; i++) {
+  //         let k = 6 + variable.name.length;
+  //         if (cell.code.slice(i, i + k) === `const ${variable.name}`) {
+  //           console.log('cell.code', cell.code)
+  //           if (i === 0) {
+  //             cell.code = cell.code.slice(6);
+  //           } else {
+  //             cell.code = cell.code.slice(0, i) + cell.code.slice(i + 6);
+  //           }
+  //           // cell.code.split('').splice(i, 6).join('');
+  //           console.log('cell.code', cell.code)
+  //           //!
+  //           resetter = true;
+  //         }
+
+  //         if (cell.code.slice(i, i + k - 2) === `let ${variable.name}`) {
+  //           console.log('cell.code', cell.code)
+  //           if (i === 0) {
+  //             cell.code = cell.code.slice(4);
+  //           } else {
+  //             cell.code = cell.code.slice(0, i) + cell.code.slice(i + 4);
+  //           }
+  //           // cell.code.split('').splice(i, 4).join('');
+  //           console.log('cell.code', cell.code)
+  //           //!MOST RECENTLY ADDED
+  //           resetter = true;
+  //         }
+  //       }
+  //       //!DELETE BELOW?
+  //       //! if cell run before and var declared w const then reset
+  //       //!OR be stringent, dont let people change a const
+  //       //!expected to fail if run 2x
+  //       if (resetter) {
+  //         resetter = false;
+  //         return 'reset'
+  //       }
+  //     } else {
+  //       //!if variable declared prev but not in this cell
+  //       //!dont do anything
+  //       //!if variable not declared previously
+  //       //! dont do anything
+  //       //reset context
+  //       console.log('before reset')
+  //       // resetContext(notebookId);
+  //       console.log('variableMapbefore', variableMap)
+  //       console.log('after reset before cellsId')
+  //       //! possible duplication
+  //       //!CAN PROB GET RID OF 
+  //       cellsRun[cell.cellId] = true;
+  //       console.log('after cellId before variableMap')
+  //       //!variables newly added to prev ran cell are now in map
+  //       //!CAN PROB GET RID OF 
+  //       variableMap[variable.type][variable.name] = cell.cellId;
+  //       console.log('after variablemap')
+  //       console.log('variableMap', variableMap)
+  //       //delete the other entry for the variable in the map 
+  //       //and create an entry for the proper variable type
+  //       //!
+  //       // return 'reset';
+  //     }
+  //     //!
+  //     // })
+  //   }
+  // }
+
+  cellVariables.variables.forEach(variable => {
+    setVarInMapV2(variable.name, variable.type, cell.cellId);
+  })
+}
+
+module.exports = { compileFrontendInput };

--- a/worker/app/utils/context.js
+++ b/worker/app/utils/context.js
@@ -17,78 +17,125 @@ Take in a notebook.
 // const main = require("./engine");
 
 const contextStore = {
-    "111": {
+  "111": {
+    active: true,
+    lastUpdate: 1687812247076,
+    context: {}
+  }
+}
+
+let variableMap = { 'const': {}, 'var': {}, 'let': {} };
+
+// {
+//   "variableName": {
+//     declaration: "const", 
+//     cellId: "cellId2385283" },
+// }
+let variableMapV2 = {};
+
+const setVarInMapV2 = (variable, declaration, cellId) => {
+  if (variableMapV2[variable]) {
+    console.log(`variable ${variable} already exists in variableMapV2`);
+    return;
+  }
+  variableMapV2[variable] = { declaration, cellId };
+}
+
+const varDeclaredInThisCell = (variable, cellId) => {
+  if (!variableMapV2[variable]) return false;
+  return variableMapV2[variable].cellId === cellId;
+}
+
+const getVarFromMapV2 = (variable) => {
+  return variableMapV2[variable];
+}
+
+const typeofDeclaration = (variable) => {
+  if (!variableMapV2[variable]) return null;
+  return variableMapV2[variable].declaration;
+}
+
+const getVarMapV2 = () => {
+  return variableMapV2;
+}
+
+
+
+const cellsRun = {};
+const declaredAt = {};
+const changedVariables = {}
+
+const updateVariableMap = (variable, value) => {
+  variableMap[variable] = value;
+}
+
+const updateCellsRun = (cellId, value) => {
+  cellsRun[cellId] = value
+}
+
+const updateDeclaredAt = (variable) => {
+  declaredAt[variable] = true;
+}
+
+const updateChangedVariables = (variable, cellId) => {
+  changedVariables[variable] = `${variable}${cellsRun[cellId]}`
+}
+
+const getVariableMap = () => {
+  return variableMap;
+}
+
+const getCellsRun = () => {
+  return cellsRun;
+}
+
+const getDeclaredAt = () => {
+  return declaredAt;
+}
+
+const getChangedVariables = () => {
+  return changedVariables;
+}
+
+const loadContext = (notebookId) => {
+  if (!contextStore.hasOwnProperty(notebookId)) {
+    contextStore[notebookId] = {
       active: true,
-      lastUpdate: 1687812247076,
-      context: {}
+      lastUpdate: Date.now(),
+      context: {},
     }
-  }
-  
-  let variableMap = {'const': {}, 'var': {}, 'let': {}};
-  const cellsRun = {};
-  const declaredAt = {};
-  const changedVariables = {}
-  
-  const updateVariableMap = (variable, value) => {
-    variableMap[variable] = value;
-  }
-  
-  const updateCellsRun = (cellId, value) => {
-    cellsRun[cellId] = value
-  }
-  
-  const updateDeclaredAt = (variable) => {
-    declaredAt[variable] = true;
-  }
-  
-  const updateChangedVariables = (variable, cellId) => {
-    changedVariables[variable] = `${variable}${cellsRun[cellId]}` 
-  }
-  
-  const getVariableMap = () => {
-    return variableMap;
-  }
-  
-  const getCellsRun = () => {
-    return cellsRun;
-  }
-  
-  const getDeclaredAt = () => {
-    return declaredAt;
-  }
-  
-  const getChangedVariables = () => {
-    return changedVariables;
-  }
-  
-  const loadContext = (notebookId) => {
-    if (!contextStore.hasOwnProperty(notebookId)) {
-      contextStore[notebookId] = {
-        active: true,
-        lastUpdate: Date.now(),
-        context: {},
-      }
-    };
-  
-    if (!contextStore[notebookId].active) {
-      contextStore[notebookId].active = true;
-      contextStore[notebookId].context = {};
-    }
-    return contextStore[notebookId].context;
-  }
-  
-  const resetContext = (notebookId) => {
-    contextStore[notebookId].active = false;
+  };
+
+  if (!contextStore[notebookId].active) {
+    contextStore[notebookId].active = true;
     contextStore[notebookId].context = {};
-    //resets the in-memory state of context in engine.js
-    // for (var member in variableMap) delete variableMap[member];
-    variableMap = {'const': {}, 'var': {}, 'let': {}};
-    for (var member in cellsRun) delete cellsRun[member];
-    for (var member in declaredAt) delete declaredAt[member];
   }
-  
-  const updateContextWrapper = (notebookId) => {
-    contextStore[notebookId].lastUpdate = Date.now();
-  }
-  
-  module.exports = { loadContext, updateContextWrapper, resetContext, getVariableMap, getCellsRun, getDeclaredAt, getChangedVariables, updateVariableMap, updateCellsRun, updateDeclaredAt, updateChangedVariables};
+  return contextStore[notebookId].context;
+}
+
+const resetContext = (notebookId) => {
+  contextStore[notebookId].active = false;
+  contextStore[notebookId].context = {};
+  //resets the in-memory state of context in engine.js
+  // for (var member in variableMap) delete variableMap[member];
+  variableMap = { 'const': {}, 'var': {}, 'let': {} };
+  variableMapV2 = {};
+
+
+  for (var member in cellsRun) delete cellsRun[member];
+  for (var member in declaredAt) delete declaredAt[member];
+}
+
+const updateContextWrapper = (notebookId) => {
+  contextStore[notebookId].lastUpdate = Date.now();
+}
+
+module.exports = {
+  loadContext, updateContextWrapper, resetContext, getVariableMap, getCellsRun, getDeclaredAt, getChangedVariables, updateVariableMap, updateCellsRun, updateDeclaredAt, updateChangedVariables,
+
+  setVarInMapV2,
+  varDeclaredInThisCell,
+  getVarFromMapV2,
+  typeofDeclaration,
+  getVarMapV2,
+};

--- a/worker/app/utils/extractVariables.js
+++ b/worker/app/utils/extractVariables.js
@@ -24,7 +24,7 @@ const extractVariables = (inputString) => {
         let target = variable[0].match(/(const|let|var)/);
         let cleaned = variable[0].replace(/(const|let|var)\s+/, "");
         let collected = cleaned.slice(0, cleaned.length-2)
-        return {type: target, name: collected};
+        return {type: target[0], name: collected};
     })
 
     console.log(variables);


### PR DESCRIPTION
Abstracted operations from FE compiler and got compilation working at a basic level for `let`.

`let` declarations  are changed to reassignments if the variable is changed in the the originating  (and previously run ) cell. No context reset needed since `let` declarations can be reassigned natively (unlike `const`).

It also can process multiple declaration statements. (Fixed looping bug)

handling of `const`, and changing of declaration types TBD.

**Important:** Variable map (named as `variableMapV2` for now) has a new structure:
```
// {
//   "variableName": {
//     declaration: "const", 
//     cellId: "cellId2385283" },
// }
```

Helpers:
`varDeclaredInThisCell`
`typeofDeclaration`
`setVarInMapV2`: Sets the variable property. If the variable already exists anywhere in the map( i.e., it was already declared anywhere), it will not be set. 
-     We may want to change this behavior pending how we want to handle changing of declaration types.

`getVarMapV2`