### PR TITLE
set 3600 second timeout on all redis keys

### DIFF
--- a/worker/app/engine.js
+++ b/worker/app/engine.js
@@ -34,6 +34,8 @@ const engine = async (apiBody, ch, msg) => {
 
       let result = executeCode(apiBody.folder, cell.cellId, cell.code, apiBody.notebookId);
       //!
+      client.setEx(apiBody.folder.toString(), 3600, JSON.stringify(result.output))
+      ch.ack(msg);
       // if (compiler === 'reset') {
       //   console.log('RESETRESET')
       //   setTimeout(() => {


### PR DESCRIPTION
this is just 2 lines of code added in the engine.js file at the bottom of the engine function.

i was thinking at first that we could do a clean up function and check against the redis hmap timecreated prop, but then found this auto timeout method...

just interesting about redis setex timeouts:
in this implementation, I set a timeout on each key right after the the executeCode function runs (which populates the redis key for the last time in the worker...) this is bc the timeout gets reset/cancelled each time the redis key's value is reset, so can't set a timeout at the beginning of the function since the value of the key will be reset throughout