### PR TITLE
workerRunning and workerStopped functions used in worker manager fn guard clauses (2)

### DIFF
--- a/server/src/utils/workerManager.js
+++ b/server/src/utils/workerManager.js
@@ -90,11 +90,6 @@ const containerActive = async (notebookId) => {
   return workerNames.map(workerName => workerName.split('.')[1]).includes(notebookId);
 };
 
-// List all containers, running or stopped
-const containerExists = async (notebookId) => {
-  const workerNames = await listWorkers({ all: true });
-  return workerNames.map(workerName => workerName.split('.')[1]).includes(notebookId);
-};
 
 const getContainerByName = async (workerName) => {
   return new Promise((resolve, reject) => {
@@ -109,6 +104,25 @@ const getContainerByName = async (workerName) => {
   })
 };
 
+const workerRunning = async (workerName) => {
+  const container = await getContainerByName(workerName);
+  if (!container) return false;
+  return container.State === 'running';
+}
+
+const workerStopped = async (workerName) => {
+  const container = await getContainerByName(workerName);
+  if (!container) return false;
+  return container.State === 'exited';
+}
+
+// List all containers, running or stopped
+const containerExists = async (notebookId) => {
+  const workerNames = await listWorkers({ all: true });
+  return workerNames.map(workerName => workerName.split('.')[1]).includes(notebookId);
+};
+
+
 const getContainerId = async (workerName) => {
   const container = await getContainerByName(workerName);
   if (!container) return null;
@@ -117,8 +131,8 @@ const getContainerId = async (workerName) => {
 
 const stopContainer = async (workerName) => {
   const id = await getContainerId(workerName);
-  if (!id) {
-    console.log(`Stopping container failed. Container not found/not active: /worker.${workerName}`);
+  if (!id || await workerStopped(workerName)) {
+    console.log(`Stopping container failed. Container not found/or already exited`);
     return null;
   };
   const container = docker.getContainer(id);
@@ -127,16 +141,17 @@ const stopContainer = async (workerName) => {
 
 const killContainer = async (workerName) => {
   const id = await getContainerId(workerName);
-  if (!id) {
-    console.log(`Killing container failed. Container not found/not active: /worker.${workerName}`);
+  if (!id || await workerStopped(workerName)) {
+    console.log(`Killing container failed. Container not found/or already exited`);
     return null;
   };
   const container = docker.getContainer(id);
   return container.kill();
 }
+
 const restartContainer = async (workerName) => {
   const id = await getContainerId(workerName);
-  if (!id) {
+  if (!id || await workerStopped(workerName)) {
     console.log(`Restarting container failed. Container not found/not active: /worker.${workerName}`);
     return null;
   };
@@ -146,19 +161,15 @@ const restartContainer = async (workerName) => {
 
 const startContainer = async (workerName) => {
   const id = await getContainerId(workerName);
-  if (!id) {
-    console.log(`Starting container failed. Container not found/not active: /worker.${workerName}`);
+
+  if (!id || await workerRunning(workerName)) {
+    console.log(`Starting container failed. Container either does not exist or is already running`);
     return null;
   };
   const container = docker.getContainer(id);
   return container.start();
 }
 
-const workerRunning = async (workerName) => {
-  const container = await getContainerByName(workerName);
-  if (!container) return false;
-  return container.State === 'running';
-}
 
 const removeContainer = async (workerName) => {
   const id = await getContainerId(workerName);
@@ -183,4 +194,4 @@ const isRunning = (workerName) => {
 
 
 
-module.exports = { listWorkers, containerActive, createNewWorker, getContainerByName, getContainerId, killContainer, restartContainer, isRunning, containerExists, workerRunning, startContainer, removeContainer }
+module.exports = { listWorkers, containerActive, createNewWorker, stopContainer, getContainerByName, getContainerId, killContainer, restartContainer, isRunning, containerExists, workerRunning, startContainer, removeContainer }


### PR DESCRIPTION
Docker will raise exceptions when killing containers that are already exited, starting containers that have already started, etc. 

We use the predicates `workerRunning` and `workerStopped` in guard clauses in the following functions in `workerManager`:

`stopContainer`
`killContainer`
`restartContainer`
`startContainer`