### PR TITLE
worker self-terminates when idle; changed daily cleanup timers

### DIFF
--- a/server/src/config.js
+++ b/server/src/config.js
@@ -14,4 +14,5 @@ module.exports = {
   WORKER_REDIS_PORT: process.env.WORKER_REDIS_PORT || 6379,
   DOCKER_HOST: process.env.DOCKER_HOST || null,
   DOCKER_PORT: process.env.DOCKER_PORT || null,
+  WORKER_IDLE_TIMEOUT_M: process.env.WORKER_IDLE_TIMEOUT_M || 15,
 }

--- a/server/src/routes/api.js
+++ b/server/src/routes/api.js
@@ -17,7 +17,6 @@ function wait(ms) {
     end = new Date().getTime();
   }
 }
-const timeouts = {};
 
 
 const sendError = (res, error) => {
@@ -97,15 +96,6 @@ router.post('/submit', async (req, res, next) => {
     res.status(202).json({
       submissionId,
     });
-
-   if(timeouts[notebookId]) {
-    clearTimeout(timeouts[notebookId])
-   };
-   timeouts[notebookId] = setTimeout(() => {
-    // console.log('container killed')
-    killContainer(`${notebookId}`)
-    deleteQueue(notebookId);
-   }, 1000*15*60)
    
   } catch (error) {
     console.log(error);

--- a/server/src/utils/cleanup.js
+++ b/server/src/utils/cleanup.js
@@ -1,37 +1,23 @@
-const {removeAllDockerContainers, flushRedis} = require('./workerManager')
-//!below line is to test redis clear cache is working
-const {getAllFields} = require('./redisHelpers');
+const { removeAllDockerContainers, flushRedis } = require('./workerManager')
 const schedule = require('node-schedule');
 
 const dailyCleanup = () => {
-    var cleanupDocker = schedule.scheduleJob({hour: 15, minute: 14} , async () => {
-        removeAllDockerContainers();
-    });
-    //!Same cleanup as one above, for now commented out
-    // schedule.scheduleJob('0 0 * * *', async () => { removeAllDockerContainers();}) // run everyday at midnight
-    //!below function is to test redis clear cache is working, 
-    //!not used in functioning of cleanup process
-    function wait(ms) {
+  var cleanupDocker = schedule.scheduleJob({ hour: 0, minute: 30 }, async () => {
+    removeAllDockerContainers();
+  });
+
+  function wait(ms) {
     var start = new Date().getTime();
     var end = start;
     while (end < start + ms) {
-        end = new Date().getTime();
+      end = new Date().getTime();
     }
-    }
+  }
 
-    var cleanupRedis =schedule.scheduleJob({hour: 0, minute: 0} , async () => {
-    //!below line is only to test redis clear cache is working
-    let before = await getAllFields('9821458b2ff376af38c3')
-    //!below line is only to test redis clear cache is working
-    console.log('before', before);
+  var cleanupRedis = schedule.scheduleJob({ hour: 0, minute: 40 }, async () => {
     flushRedis();
-    //!below line is only to test redis clear cache is working
     wait(5000)
-    //!below line is only to test redis clear cache is working
-    let after = await getAllFields('9821458b2ff376af38c3')
-    //!below line is only to test redis clear cache is working
-    console.log('after', after);
-    });
+  });
 }
 
 module.exports = { dailyCleanup };

--- a/server/src/utils/workerManager.js
+++ b/server/src/utils/workerManager.js
@@ -5,6 +5,7 @@ const { NETWORK_NAME,
   WORKER_REDIS_PORT,
   DOCKER_HOST,
   DOCKER_PORT,
+  WORKER_IDLE_TIMEOUT_M,
 } = require('../config');
 
 const MEMORY_LIMIT = 100; // in mb;
@@ -99,7 +100,8 @@ const createNewWorker = async (notebookId) => {
         `QUEUE_HOST=${WORKER_QUEUE_HOST}`,
         `QUEUE_PORT=${WORKER_QUEUE_PORT}`,
         `REDIS_HOST=${WORKER_REDIS_HOST}`,
-        `REDIS_PORT=${WORKER_REDIS_PORT}`
+        `REDIS_PORT=${WORKER_REDIS_PORT}`,
+        `WORKER_IDLE_TIMEOUT_M=${WORKER_IDLE_TIMEOUT_M}}`,
       ],
       WorkingDir: '/app',
       AttachStdin: false,


### PR DESCRIPTION
**self-terminating workers.** Worker `rabbitmq.js` updated to self terminate if a message is not received in the last 15 minutes (default value timeout). This value, in minutes, can be changed in the `.env` file in `server`, under the name `WORKER_IDLE_TIMEOUT_M`. 

**api notebook timeouts deprecated**. The above update deprecates the notebook `timeouts` variable that also terminated workers if they were idle. There were some issues with the previous implementation, but the main problem was tight coupling of cleanup functions with the api server. 

The goal of this change along with https://github.com/PennantHQ/pennant-engine/pull/47 https://github.com/PennantHQ/pennant-engine/pull/49 is to increase robustness of both the docker host and api server, should the api server go down.


@landzbej  the other cleanup functions originating in api-server that clean up docker images, queues, and redis are preserved. File `cleanup.js` edited to run at 00:30 Pacific.

