### PR TITLE
Initialize worker self-termination timer immediately after creating channel

### DIFF
--- a/worker/app/config/rabbitmq.js
+++ b/worker/app/config/rabbitmq.js
@@ -8,6 +8,7 @@ const QUEUE_PORT = process.env.QUEUE_PORT;
 const WORKER_IDLE_TIMEOUT = process.env.WORKER_IDLE_TIMEOUT_M * 60 * 1000 ||
   15 * 60 * 1000; // 15 minutes default
 
+
 console.log("Establishing connection to broker ", QUEUE_HOST, QUEUE_PORT);
 console.log("Queue name is: ", QUEUE_NAME);
 const connection = amqp.connect([`${QUEUE_HOST}:${QUEUE_PORT}`]);
@@ -54,6 +55,8 @@ const channelWrapper = connection.createChannel({
     ]);
   }
 });
+
+resetTimer();
 
 const listenMessage = async (data) => {
   channelWrapper.waitForConnect()


### PR DESCRIPTION
Discovered a bug where Redis exceptions on startup prevented workers from automatically destroying themselves. Self termination was re-enabled upon the first successful consumption of a message.

Since Redis exceptions in `engine` prevent successful message consumption, the self-termination timer would never be set in such instances.

This fix initiates the timer immediately by calling it as soon as the connection with the queue is created. The timer resets as usual when messages are consumed.