### PR TITLE
redis reconnection logic

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "2.3" #Use this version strictly
 services:
   redis-dredd:
     image: redis
-    command: redis-server --requirepass ${REDIS_PASSWORD}
+    command: redis-server --requirepass ${REDIS_PASSWORD} --maxmemory 128mb --maxmemory-policy allkeys-lru
     container_name: redis-dredd
     restart: always
     ports:

--- a/server/src/config/rabbitmq.js
+++ b/server/src/config/rabbitmq.js
@@ -62,10 +62,10 @@ const deleteQueue = async (queueName) => {
 (async () => {
   await initializeConnection();
   connection.on('connect', function () {
-    console.log('Connected!');
+    console.log('Connected to broker!');
   });
   connection.on('disconnect', function (err) {
-    console.log('Disconnected.', err);
+    console.log('Disconnected from broker.', err);
   });
 
 })();

--- a/server/src/config/redis.js
+++ b/server/src/config/redis.js
@@ -1,7 +1,7 @@
 const { REDIS_HOST, REDIS_PORT, REDIS_PASSWORD } = require("../config");
 const redis = require("redis");
 
-const client = redis.createClient({
+const clientOptions = {
   legacyMode: true,
   socket: {
     // host: "127.0.0.1",
@@ -9,15 +9,42 @@ const client = redis.createClient({
     // ! When running server on host machine, use 127.0.0.1
     host: REDIS_HOST,
     port: REDIS_PORT,
+    reconnectStrategy (retries) {
+      if (retries > 10) {
+        console.log("Too many retries on REDIS. Connection Terminated");
+        return new Error("Too many retries.");
+      } else {
+        return retries;
+      }
+    },
   },
   password: REDIS_PASSWORD,
-});
 
-client.connect().then(
 
-  client.on("error", (err) => {
-    console.log("Error " + err);
-  })
-);
+}
+
+
+let client;
+
+(async () => {
+  client = redis.createClient(clientOptions);
+
+  client.on("connect", () => {
+    console.log("Connected to Redis!");
+  });
+
+  client.on("error", (error) => {
+    console.error(`Redis Error : ${error}`)
+    process.exit(1);
+  });
+
+  await client.connect();
+})();
+
+
+
+// client.on("error", (err) => {
+//   console.log("Error " + err);
+// })
 
 module.exports = { client }


### PR DESCRIPTION
The bug from last week that caused all code requests to fail had to do with API server disconnections from the Redis cache. 

This fix implements reconnect logic, and it restarts node application if the Redis socket closes unexpectedly.