### PR TITLE
Fix execution outputs for run many cell requests

### DIFF
--- a/worker/app/engine.js
+++ b/worker/app/engine.js
@@ -71,6 +71,7 @@ const executeCode = async (submissionId, cellId, code) => {
   } catch (error) {
     arr.push(String(error));
     isSyntaxOrRuntimeError = true;
+    throw error;
 
   } finally {
     updateSubmissionOutput(submissionId, cellId, isSyntaxOrRuntimeError, arr.join(''));


### PR DESCRIPTION
Fixes this bug: Duplicated outputs running many cells.
e.g., [cell1: console.log('bob'), cell2: console.log('cat')]
> cat, cat

Cause of the error was setting redis hkey to the output object produced by the executed cell. This lead to only the last evaluated cell's output being written.

Fix only assigns the redis hkey only after all cells have been run.